### PR TITLE
Switch accounts using sandbox account id

### DIFF
--- a/modules/development-team/README.md
+++ b/modules/development-team/README.md
@@ -35,7 +35,13 @@ storing this password using 1Password.
 **Switch Role**
 You have your own AWS account which is unique to you in which you can
 experiment and deploy with AWS services.
-[Switch to that account as an administrator][Switch to Account].
+[Switch to that account as an administrator][Switch to Account]. 
+
+* `Account` should be the ID for your Sandbox account which you should receive
+with your credentials.
+* `Role` should be `Administrator`
+* `Display name` is anything of your choosing, though we recommend _Sparkbox
+Sandbox Account_
 
 You now have the ability to create new resources under your account, while
 billing is managed by the Sparkbox Main Account. Budget alerts are configured,
@@ -46,4 +52,4 @@ Technical Director.
 
 [AWS Organizations]: https://docs.aws.amazon.com/organizations/?id=docs_gateway
 [Accessing Member Accounts]: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_access.html
-[Switch to Account]: https://signin.aws.amazon.com/switchrole?roleName=OrganizationAccountAccessRole-466417273521&account=sparkbox
+[Switch to Account]: https://signin.aws.amazon.com/switchrole?roleName=Administrator&account=


### PR DESCRIPTION
Role switching involves specifying the account in which the role
(Administrator) resides. We were specifying the `sparkbox` account and
permission and Role which gives access to the role in the sandbox
account.